### PR TITLE
feat(frontend): bookmark activities + reorder on /profil

### DIFF
--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.8.8",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.11.1",
         "@emotion/server": "^11.11.0",
         "@mantine/core": "^6.0.16",
@@ -1230,6 +1233,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -15,6 +15,9 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.8",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@mantine/core": "^6.0.16",
@@ -44,8 +47,8 @@
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",
     "jsdom": "^22.1.0",
-    "typescript": "5.1.6",
     "prettier": "^2.8.8",
+    "typescript": "5.1.6",
     "vitest": "^0.33.0"
   }
 }

--- a/front-end/src/components/Activity.tsx
+++ b/front-end/src/components/Activity.tsx
@@ -2,6 +2,7 @@ import { ActivityFragment } from '@/graphql/generated/types';
 import { useGlobalStyles } from '@/utils';
 import { Badge, Button, Card, Grid, Group, Image, Text } from '@mantine/core';
 import Link from 'next/link';
+import { BookmarkButton } from './BookmarkButton';
 
 interface ActivityProps {
   activity: ActivityFragment;
@@ -21,10 +22,11 @@ export function Activity({ activity }: ActivityProps) {
           />
         </Card.Section>
 
-        <Group position="apart" mt="md" mb="xs">
+        <Group position="apart" mt="md" mb="xs" noWrap>
           <Text weight={500} className={classes.ellipsis}>
             {activity.name}
           </Text>
+          <BookmarkButton activityId={activity.id} />
         </Group>
 
         <Group mt="md" mb="xs">

--- a/front-end/src/components/ActivityListItem.tsx
+++ b/front-end/src/components/ActivityListItem.tsx
@@ -1,7 +1,8 @@
 import { ActivityFragment } from '@/graphql/generated/types';
 import { useGlobalStyles } from '@/utils';
-import { Box, Button, Flex, Image, Text } from '@mantine/core';
+import { Box, Button, Flex, Group, Image, Text } from '@mantine/core';
 import Link from 'next/link';
+import { BookmarkButton } from './BookmarkButton';
 
 interface ActivityListItemProps {
   activity: ActivityFragment;
@@ -30,11 +31,14 @@ export function ActivityListItem({ activity }: ActivityListItemProps) {
           >{`${activity.price}€/j`}</Text>
         </Box>
       </Flex>
-      <Link href={`/activities/${activity.id}`} className={classes.link}>
-        <Button variant="outline" color="dark">
-          Voir plus
-        </Button>
-      </Link>
+      <Group spacing="xs">
+        <BookmarkButton activityId={activity.id} />
+        <Link href={`/activities/${activity.id}`} className={classes.link}>
+          <Button variant="outline" color="dark">
+            Voir plus
+          </Button>
+        </Link>
+      </Group>
     </Flex>
   );
 }

--- a/front-end/src/components/BookmarkButton/BookmarkButton.test.tsx
+++ b/front-end/src/components/BookmarkButton/BookmarkButton.test.tsx
@@ -1,4 +1,4 @@
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
@@ -34,7 +34,7 @@ const renderWith = ({
   mocks,
 }: {
   user: GetUserQuery['getMe'] | null;
-  mocks: Parameters<typeof MockedProvider>[0]['mocks'];
+  mocks: ReadonlyArray<MockedResponse>;
 }) => {
   const refreshUser = vi.fn().mockResolvedValue(undefined);
   render(

--- a/front-end/src/components/BookmarkButton/BookmarkButton.test.tsx
+++ b/front-end/src/components/BookmarkButton/BookmarkButton.test.tsx
@@ -1,0 +1,111 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { AuthContext } from '@/contexts/authContext';
+import AddBookmark from '@/graphql/mutations/bookmark/addBookmark';
+import RemoveBookmark from '@/graphql/mutations/bookmark/removeBookmark';
+import { GetUserQuery } from '@/graphql/generated/types';
+import { BookmarkButton } from './BookmarkButton';
+
+const activityFixture = {
+  __typename: 'Activity' as const,
+  id: 'activity-1',
+  city: 'city',
+  description: 'description',
+  name: 'name',
+  price: 10,
+  owner: { __typename: 'User' as const, firstName: 'John', lastName: 'Doe' },
+};
+
+const userFixture = (
+  bookmarks: GetUserQuery['getMe']['bookmarks'],
+): GetUserQuery['getMe'] => ({
+  __typename: 'User',
+  id: 'user-1',
+  firstName: 'John',
+  lastName: 'Doe',
+  email: 'john@test.fr',
+  bookmarks,
+});
+
+const renderWith = ({
+  user,
+  mocks,
+}: {
+  user: GetUserQuery['getMe'] | null;
+  mocks: Parameters<typeof MockedProvider>[0]['mocks'];
+}) => {
+  const refreshUser = vi.fn().mockResolvedValue(undefined);
+  render(
+    <MockedProvider mocks={mocks} addTypename={true}>
+      <AuthContext.Provider
+        value={{
+          user,
+          isLoading: false,
+          handleSignin: () => Promise.resolve(),
+          handleSignup: () => Promise.resolve(),
+          handleLogout: () => Promise.resolve(),
+          refreshUser,
+        }}
+      >
+        <BookmarkButton activityId="activity-1" />
+      </AuthContext.Provider>
+    </MockedProvider>,
+  );
+  return { refreshUser };
+};
+
+describe('BookmarkButton', () => {
+  it('renders nothing when no user is signed in', () => {
+    renderWith({ user: null, mocks: [] });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('calls addBookmark when the activity is not yet bookmarked', async () => {
+    const result = vi.fn(() => ({
+      data: {
+        addBookmark: { __typename: 'User', id: 'user-1', bookmarks: [activityFixture] },
+      },
+    }));
+    const { refreshUser } = renderWith({
+      user: userFixture([]),
+      mocks: [
+        {
+          request: { query: AddBookmark, variables: { activityId: 'activity-1' } },
+          result,
+        },
+      ],
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Ajouter aux favoris/i }));
+
+    await waitFor(() => expect(result).toHaveBeenCalled());
+    await waitFor(() => expect(refreshUser).toHaveBeenCalled());
+  });
+
+  it('calls removeBookmark when the activity is already bookmarked', async () => {
+    const result = vi.fn(() => ({
+      data: {
+        removeBookmark: { __typename: 'User', id: 'user-1', bookmarks: [] },
+      },
+    }));
+    const { refreshUser } = renderWith({
+      user: userFixture([activityFixture]),
+      mocks: [
+        {
+          request: {
+            query: RemoveBookmark,
+            variables: { activityId: 'activity-1' },
+          },
+          result,
+        },
+      ],
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Retirer des favoris/i }));
+
+    await waitFor(() => expect(result).toHaveBeenCalled());
+    await waitFor(() => expect(refreshUser).toHaveBeenCalled());
+  });
+});

--- a/front-end/src/components/BookmarkButton/BookmarkButton.tsx
+++ b/front-end/src/components/BookmarkButton/BookmarkButton.tsx
@@ -1,0 +1,70 @@
+import {
+  AddBookmarkMutation,
+  AddBookmarkMutationVariables,
+  RemoveBookmarkMutation,
+  RemoveBookmarkMutationVariables,
+} from '@/graphql/generated/types';
+import AddBookmark from '@/graphql/mutations/bookmark/addBookmark';
+import RemoveBookmark from '@/graphql/mutations/bookmark/removeBookmark';
+import { useAuth, useSnackbar } from '@/hooks';
+import { useMutation } from '@apollo/client';
+import { ActionIcon, Tooltip } from '@mantine/core';
+import { IconBookmark, IconBookmarkFilled } from '@tabler/icons-react';
+import { MouseEvent } from 'react';
+
+interface BookmarkButtonProps {
+  activityId: string;
+}
+
+export function BookmarkButton({ activityId }: BookmarkButtonProps) {
+  const { user, refreshUser } = useAuth();
+  const snackbar = useSnackbar();
+
+  const [addBookmark, addState] = useMutation<
+    AddBookmarkMutation,
+    AddBookmarkMutationVariables
+  >(AddBookmark);
+  const [removeBookmark, removeState] = useMutation<
+    RemoveBookmarkMutation,
+    RemoveBookmarkMutationVariables
+  >(RemoveBookmark);
+
+  if (!user) return null;
+
+  const isBookmarked = user.bookmarks.some((b) => b.id === activityId);
+  const isLoading = addState.loading || removeState.loading;
+
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      if (isBookmarked) {
+        await removeBookmark({ variables: { activityId } });
+      } else {
+        await addBookmark({ variables: { activityId } });
+      }
+      await refreshUser();
+    } catch {
+      snackbar.error('Une erreur est survenue');
+    }
+  };
+
+  return (
+    <Tooltip label={isBookmarked ? 'Retirer des favoris' : 'Ajouter aux favoris'}>
+      <ActionIcon
+        variant={isBookmarked ? 'filled' : 'light'}
+        color="yellow"
+        onClick={handleClick}
+        loading={isLoading}
+        aria-label={isBookmarked ? 'Retirer des favoris' : 'Ajouter aux favoris'}
+        aria-pressed={isBookmarked}
+      >
+        {isBookmarked ? (
+          <IconBookmarkFilled size="1.125rem" />
+        ) : (
+          <IconBookmark size="1.125rem" />
+        )}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/front-end/src/components/BookmarkButton/index.ts
+++ b/front-end/src/components/BookmarkButton/index.ts
@@ -1,0 +1,1 @@
+export * from './BookmarkButton';

--- a/front-end/src/components/BookmarksList/BookmarksList.tsx
+++ b/front-end/src/components/BookmarksList/BookmarksList.tsx
@@ -39,8 +39,8 @@ import {
   IconGripVertical,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
-import { BookmarkButton } from '../BookmarkButton';
+import { useEffect, useRef, useState } from 'react';
+import { BookmarkButton } from '@/components/BookmarkButton';
 
 interface BookmarkRowProps {
   activity: ActivityFragment;
@@ -128,6 +128,7 @@ export function BookmarksList() {
     ReorderBookmarksMutation,
     ReorderBookmarksMutationVariables
   >(ReorderBookmarks);
+  const latestRequestId = useRef(0);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -140,13 +141,16 @@ export function BookmarksList() {
 
   const persistOrder = async (next: ActivityFragment[]) => {
     const previous = items;
+    const requestId = ++latestRequestId.current;
     setItems(next);
     try {
       await reorderBookmarks({
         variables: { orderedIds: next.map((b) => b.id) },
       });
     } catch {
-      setItems(previous);
+      if (requestId === latestRequestId.current) {
+        setItems(previous);
+      }
       snackbar.error('Une erreur est survenue');
     }
   };

--- a/front-end/src/components/BookmarksList/BookmarksList.tsx
+++ b/front-end/src/components/BookmarksList/BookmarksList.tsx
@@ -118,7 +118,7 @@ function BookmarkRow({ activity, index, total, onMove }: BookmarkRowProps) {
 }
 
 export function BookmarksList() {
-  const { user, refreshUser } = useAuth();
+  const { user } = useAuth();
   const snackbar = useSnackbar();
   const [items, setItems] = useState<ActivityFragment[]>(
     user?.bookmarks ?? [],
@@ -145,7 +145,6 @@ export function BookmarksList() {
       await reorderBookmarks({
         variables: { orderedIds: next.map((b) => b.id) },
       });
-      await refreshUser();
     } catch {
       setItems(previous);
       snackbar.error('Une erreur est survenue');

--- a/front-end/src/components/BookmarksList/BookmarksList.tsx
+++ b/front-end/src/components/BookmarksList/BookmarksList.tsx
@@ -1,0 +1,205 @@
+import {
+  ActivityFragment,
+  ReorderBookmarksMutation,
+  ReorderBookmarksMutationVariables,
+} from '@/graphql/generated/types';
+import ReorderBookmarks from '@/graphql/mutations/bookmark/reorderBookmarks';
+import { useAuth, useSnackbar } from '@/hooks';
+import { useMutation } from '@apollo/client';
+import {
+  ActionIcon,
+  Box,
+  Button,
+  Flex,
+  Group,
+  Stack,
+  Text,
+} from '@mantine/core';
+import {
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import {
+  IconBookmarkOff,
+  IconChevronDown,
+  IconChevronUp,
+  IconGripVertical,
+} from '@tabler/icons-react';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { BookmarkButton } from '../BookmarkButton';
+
+interface BookmarkRowProps {
+  activity: ActivityFragment;
+  index: number;
+  total: number;
+  onMove: (from: number, to: number) => void;
+}
+
+function BookmarkRow({ activity, index, total, onMove }: BookmarkRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: activity.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={style}
+      sx={(theme) => ({
+        padding: theme.spacing.sm,
+        borderRadius: theme.radius.md,
+        border: `1px solid ${theme.colors.gray[3]}`,
+        backgroundColor: theme.white,
+      })}
+    >
+      <Flex align="center" gap="md">
+        <ActionIcon
+          {...attributes}
+          {...listeners}
+          variant="subtle"
+          aria-label="Réordonner par glisser-déposer"
+          sx={{ cursor: 'grab', touchAction: 'none' }}
+        >
+          <IconGripVertical size="1.125rem" />
+        </ActionIcon>
+
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Text weight={500}>{activity.name}</Text>
+          <Text size="sm" color="dimmed">
+            {activity.city} — {activity.price}€/j
+          </Text>
+        </Box>
+
+        <Group spacing={4}>
+          <ActionIcon
+            variant="default"
+            disabled={index === 0}
+            onClick={() => onMove(index, index - 1)}
+            aria-label="Monter"
+          >
+            <IconChevronUp size="1.125rem" />
+          </ActionIcon>
+          <ActionIcon
+            variant="default"
+            disabled={index === total - 1}
+            onClick={() => onMove(index, index + 1)}
+            aria-label="Descendre"
+          >
+            <IconChevronDown size="1.125rem" />
+          </ActionIcon>
+          <Link href={`/activities/${activity.id}`}>
+            <Button variant="subtle" size="xs">
+              Voir
+            </Button>
+          </Link>
+          <BookmarkButton activityId={activity.id} />
+        </Group>
+      </Flex>
+    </Box>
+  );
+}
+
+export function BookmarksList() {
+  const { user, refreshUser } = useAuth();
+  const snackbar = useSnackbar();
+  const [items, setItems] = useState<ActivityFragment[]>(
+    user?.bookmarks ?? [],
+  );
+
+  const [reorderBookmarks] = useMutation<
+    ReorderBookmarksMutation,
+    ReorderBookmarksMutationVariables
+  >(ReorderBookmarks);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  useEffect(() => {
+    setItems(user?.bookmarks ?? []);
+  }, [user?.bookmarks]);
+
+  const persistOrder = async (next: ActivityFragment[]) => {
+    const previous = items;
+    setItems(next);
+    try {
+      await reorderBookmarks({
+        variables: { orderedIds: next.map((b) => b.id) },
+      });
+      await refreshUser();
+    } catch {
+      setItems(previous);
+      snackbar.error('Une erreur est survenue');
+    }
+  };
+
+  const handleMove = (from: number, to: number) => {
+    if (to < 0 || to >= items.length || from === to) return;
+    persistOrder(arrayMove(items, from, to));
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = items.findIndex((b) => b.id === active.id);
+    const to = items.findIndex((b) => b.id === over.id);
+    if (from === -1 || to === -1) return;
+    persistOrder(arrayMove(items, from, to));
+  };
+
+  if (items.length === 0) {
+    return (
+      <Flex direction="column" align="center" gap="sm" py="xl">
+        <IconBookmarkOff size="2rem" />
+        <Text color="dimmed">Vous n&apos;avez encore aucune activité en favori.</Text>
+        <Link href="/discover">
+          <Button variant="light">Découvrir des activités</Button>
+        </Link>
+      </Flex>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map((b) => b.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <Stack spacing="sm">
+          {items.map((activity, index) => (
+            <BookmarkRow
+              key={activity.id}
+              activity={activity}
+              index={index}
+              total={items.length}
+              onMove={handleMove}
+            />
+          ))}
+        </Stack>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/front-end/src/components/BookmarksList/index.ts
+++ b/front-end/src/components/BookmarksList/index.ts
@@ -1,0 +1,1 @@
+export * from './BookmarksList';

--- a/front-end/src/components/Topbar/__tests__/getFilteredRoutes.test.ts
+++ b/front-end/src/components/Topbar/__tests__/getFilteredRoutes.test.ts
@@ -14,6 +14,7 @@ const user: GetUserQuery['getMe'] = {
   email: 'user1@test.fr',
   firstName: 'john',
   lastName: 'doe',
+  bookmarks: [],
 };
 
 describe('la fonction checkRouteAccess', () => {

--- a/front-end/src/components/index.ts
+++ b/front-end/src/components/index.ts
@@ -1,5 +1,7 @@
 export * from './Activity';
 export * from './ActivityListItem';
+export * from './BookmarkButton';
+export * from './BookmarksList';
 export * from './City';
 export * from './EmptyData';
 export * from './Filters';

--- a/front-end/src/contexts/authContext.tsx
+++ b/front-end/src/contexts/authContext.tsx
@@ -25,6 +25,7 @@ interface AuthContextType {
   handleSignin: (input: SignInInput) => Promise<void>;
   handleSignup: (input: SignUpInput) => Promise<void>;
   handleLogout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -33,6 +34,7 @@ export const AuthContext = createContext<AuthContextType>({
   handleSignin: () => Promise.resolve(),
   handleSignup: () => Promise.resolve(),
   handleLogout: () => Promise.resolve(),
+  refreshUser: () => Promise.resolve(),
 });
 
 interface AuthProviderProps {
@@ -103,9 +105,21 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     }
   };
 
+  const refreshUser = async () => {
+    const res = await getUser({ fetchPolicy: 'network-only' });
+    setUser(res.data?.getMe || null);
+  };
+
   return (
     <AuthContext.Provider
-      value={{ user, isLoading, handleSignin, handleSignup, handleLogout }}
+      value={{
+        user,
+        isLoading,
+        handleSignin,
+        handleSignup,
+        handleLogout,
+        refreshUser,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/front-end/src/contexts/authContext.tsx
+++ b/front-end/src/contexts/authContext.tsx
@@ -106,8 +106,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   };
 
   const refreshUser = async () => {
-    const res = await getUser({ fetchPolicy: 'network-only' });
-    setUser(res.data?.getMe || null);
+    try {
+      const res = await getUser({ fetchPolicy: 'network-only' });
+      setUser(res.data?.getMe || null);
+    } catch (err) {
+      snackbar.error('Une erreur est survenue');
+    }
   };
 
   return (

--- a/front-end/src/graphql/generated/types.ts
+++ b/front-end/src/graphql/generated/types.ts
@@ -1,39 +1,21 @@
-import {
-  GraphQLResolveInfo,
-  GraphQLScalarType,
-  GraphQLScalarTypeConfig,
-} from 'graphql';
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T,
-> = { [_ in K]?: never };
-export type Incremental<T> =
-  | T
-  | {
-      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
-    };
-export type RequireFields<T, K extends keyof T> = Omit<T, K> & {
-  [P in K]-?: NonNullable<T[P]>;
-};
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  DateTime: { input: any; output: any };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  /** A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format. */
+  DateTime: { input: any; output: any; }
 };
 
 export type Activity = {
@@ -56,22 +38,43 @@ export type CreateActivityInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
+  addBookmark: User;
   createActivity: Activity;
   login: SignInDto;
   logout: Scalars['Boolean']['output'];
   register: User;
+  removeBookmark: User;
+  reorderBookmarks: User;
 };
+
+
+export type MutationAddBookmarkArgs = {
+  activityId: Scalars['ID']['input'];
+};
+
 
 export type MutationCreateActivityArgs = {
   createActivityInput: CreateActivityInput;
 };
 
+
 export type MutationLoginArgs = {
   signInInput: SignInInput;
 };
 
+
 export type MutationRegisterArgs = {
   signUpInput: SignUpInput;
+};
+
+
+export type MutationRemoveBookmarkArgs = {
+  activityId: Scalars['ID']['input'];
+};
+
+
+export type MutationReorderBookmarksArgs = {
+  orderedIds: Array<Scalars['ID']['input']>;
 };
 
 export type Query = {
@@ -85,11 +88,13 @@ export type Query = {
   getMe: User;
 };
 
+
 export type QueryGetActivitiesByCityArgs = {
   activity?: InputMaybe<Scalars['String']['input']>;
   city: Scalars['String']['input'];
   price?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 export type QueryGetActivityArgs = {
   id: Scalars['String']['input'];
@@ -114,6 +119,7 @@ export type SignUpInput = {
 
 export type User = {
   __typename?: 'User';
+  bookmarks: Array<Activity>;
   email: Scalars['String']['output'];
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
@@ -121,81 +127,61 @@ export type User = {
   password: Scalars['String']['output'];
 };
 
-export type ActivityFragment = {
-  __typename?: 'Activity';
-  id: string;
-  city: string;
-  description: string;
-  name: string;
-  price: number;
-  owner: { __typename?: 'User'; firstName: string; lastName: string };
-};
+export type ActivityFragment = { __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } };
 
-export type OwnerFragment = {
-  __typename?: 'User';
-  firstName: string;
-  lastName: string;
-};
+export type OwnerFragment = { __typename?: 'User', firstName: string, lastName: string };
 
 export type CreateActivityMutationVariables = Exact<{
   createActivityInput: CreateActivityInput;
 }>;
 
-export type CreateActivityMutation = {
-  __typename?: 'Mutation';
-  createActivity: {
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  };
-};
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never }>;
+export type CreateActivityMutation = { __typename?: 'Mutation', createActivity: { __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } } };
 
-export type LogoutMutation = { __typename?: 'Mutation'; logout: boolean };
+export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LogoutMutation = { __typename?: 'Mutation', logout: boolean };
 
 export type SigninMutationVariables = Exact<{
   signInInput: SignInInput;
 }>;
 
-export type SigninMutation = {
-  __typename?: 'Mutation';
-  login: { __typename?: 'SignInDto'; access_token: string };
-};
+
+export type SigninMutation = { __typename?: 'Mutation', login: { __typename?: 'SignInDto', access_token: string } };
 
 export type SignupMutationVariables = Exact<{
   signUpInput: SignUpInput;
 }>;
 
-export type SignupMutation = {
-  __typename?: 'Mutation';
-  register: {
-    __typename?: 'User';
-    id: string;
-    email: string;
-    firstName: string;
-    lastName: string;
-  };
-};
 
-export type GetActivitiesQueryVariables = Exact<{ [key: string]: never }>;
+export type SignupMutation = { __typename?: 'Mutation', register: { __typename?: 'User', id: string, email: string, firstName: string, lastName: string } };
 
-export type GetActivitiesQuery = {
-  __typename?: 'Query';
-  getActivities: Array<{
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  }>;
-};
+export type AddBookmarkMutationVariables = Exact<{
+  activityId: Scalars['ID']['input'];
+}>;
+
+
+export type AddBookmarkMutation = { __typename?: 'Mutation', addBookmark: { __typename?: 'User', id: string, bookmarks: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> } };
+
+export type RemoveBookmarkMutationVariables = Exact<{
+  activityId: Scalars['ID']['input'];
+}>;
+
+
+export type RemoveBookmarkMutation = { __typename?: 'Mutation', removeBookmark: { __typename?: 'User', id: string, bookmarks: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> } };
+
+export type ReorderBookmarksMutationVariables = Exact<{
+  orderedIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+}>;
+
+
+export type ReorderBookmarksMutation = { __typename?: 'Mutation', reorderBookmarks: { __typename?: 'User', id: string, bookmarks: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> } };
+
+export type GetActivitiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetActivitiesQuery = { __typename?: 'Query', getActivities: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> };
 
 export type GetActivitiesByCityQueryVariables = Exact<{
   activity?: InputMaybe<Scalars['String']['input']>;
@@ -203,132 +189,70 @@ export type GetActivitiesByCityQueryVariables = Exact<{
   price?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GetActivitiesByCityQuery = {
-  __typename?: 'Query';
-  getActivitiesByCity: Array<{
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  }>;
-};
+
+export type GetActivitiesByCityQuery = { __typename?: 'Query', getActivitiesByCity: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> };
 
 export type GetActivityQueryVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
-export type GetActivityQuery = {
-  __typename?: 'Query';
-  getActivity: {
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  };
-};
 
-export type GetLatestActivitiesQueryVariables = Exact<{ [key: string]: never }>;
+export type GetActivityQuery = { __typename?: 'Query', getActivity: { __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } } };
 
-export type GetLatestActivitiesQuery = {
-  __typename?: 'Query';
-  getLatestActivities: Array<{
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  }>;
-};
+export type GetLatestActivitiesQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type GetUserActivitiesQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GetUserActivitiesQuery = {
-  __typename?: 'Query';
-  getActivitiesByUser: Array<{
-    __typename?: 'Activity';
-    id: string;
-    city: string;
-    description: string;
-    name: string;
-    price: number;
-    owner: { __typename?: 'User'; firstName: string; lastName: string };
-  }>;
-};
+export type GetLatestActivitiesQuery = { __typename?: 'Query', getLatestActivities: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> };
 
-export type GetUserQueryVariables = Exact<{ [key: string]: never }>;
+export type GetUserActivitiesQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type GetUserQuery = {
-  __typename?: 'Query';
-  getMe: {
-    __typename?: 'User';
-    id: string;
-    firstName: string;
-    lastName: string;
-    email: string;
-  };
-};
 
-export type GetCitiesQueryVariables = Exact<{ [key: string]: never }>;
+export type GetUserActivitiesQuery = { __typename?: 'Query', getActivitiesByUser: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> };
 
-export type GetCitiesQuery = { __typename?: 'Query'; getCities: Array<string> };
+export type GetUserQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetUserQuery = { __typename?: 'Query', getMe: { __typename?: 'User', id: string, firstName: string, lastName: string, email: string, bookmarks: Array<{ __typename?: 'Activity', id: string, city: string, description: string, name: string, price: number, owner: { __typename?: 'User', firstName: string, lastName: string } }> } };
+
+export type GetCitiesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetCitiesQuery = { __typename?: 'Query', getCities: Array<string> };
+
+
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
+
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
-  | ResolverFn<TResult, TParent, TContext, TArgs>
-  | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
-export interface SubscriptionSubscriberObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs,
-> {
-  subscribe: SubscriptionSubscribeFn<
-    { [key in TKey]: TResult },
-    TParent,
-    TContext,
-    TArgs
-  >;
-  resolve?: SubscriptionResolveFn<
-    TResult,
-    { [key in TKey]: TResult },
-    TContext,
-    TArgs
-  >;
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
 }
 
 export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
@@ -336,54 +260,33 @@ export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
   resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
 }
 
-export type SubscriptionObject<
-  TResult,
-  TKey extends string,
-  TParent,
-  TContext,
-  TArgs,
-> =
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
   | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
   | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
 
-export type SubscriptionResolver<
-  TResult,
-  TKey extends string,
-  TParent = {},
-  TContext = {},
-  TArgs = {},
-> =
-  | ((
-      ...args: any[]
-    ) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
   | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
 
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
-  obj: T,
-  context: TContext,
-  info: GraphQLResolveInfo,
-) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
-export type DirectiveResolverFn<
-  TResult = {},
-  TParent = {},
-  TContext = {},
-  TArgs = {},
-> = (
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
   next: NextResolverFn<TResult>,
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo,
+  info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
+
+
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = {
@@ -419,16 +322,9 @@ export type ResolversParentTypes = {
   User: User;
 };
 
-export type ActivityResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Activity'] = ResolversParentTypes['Activity'],
-> = {
+export type ActivityResolvers<ContextType = any, ParentType extends ResolversParentTypes['Activity'] = ResolversParentTypes['Activity']> = {
   city?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  createdAt?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
+  createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -437,87 +333,37 @@ export type ActivityResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export interface DateTimeScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
   name: 'DateTime';
 }
 
-export type MutationResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation'],
-> = {
-  createActivity?: Resolver<
-    ResolversTypes['Activity'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateActivityArgs, 'createActivityInput'>
-  >;
-  login?: Resolver<
-    ResolversTypes['SignInDto'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationLoginArgs, 'signInInput'>
-  >;
+export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
+  addBookmark?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationAddBookmarkArgs, 'activityId'>>;
+  createActivity?: Resolver<ResolversTypes['Activity'], ParentType, ContextType, RequireFields<MutationCreateActivityArgs, 'createActivityInput'>>;
+  login?: Resolver<ResolversTypes['SignInDto'], ParentType, ContextType, RequireFields<MutationLoginArgs, 'signInInput'>>;
   logout?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  register?: Resolver<
-    ResolversTypes['User'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationRegisterArgs, 'signUpInput'>
-  >;
+  register?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationRegisterArgs, 'signUpInput'>>;
+  removeBookmark?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationRemoveBookmarkArgs, 'activityId'>>;
+  reorderBookmarks?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationReorderBookmarksArgs, 'orderedIds'>>;
 };
 
-export type QueryResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query'],
-> = {
-  getActivities?: Resolver<
-    Array<ResolversTypes['Activity']>,
-    ParentType,
-    ContextType
-  >;
-  getActivitiesByCity?: Resolver<
-    Array<ResolversTypes['Activity']>,
-    ParentType,
-    ContextType,
-    RequireFields<QueryGetActivitiesByCityArgs, 'city'>
-  >;
-  getActivitiesByUser?: Resolver<
-    Array<ResolversTypes['Activity']>,
-    ParentType,
-    ContextType
-  >;
-  getActivity?: Resolver<
-    ResolversTypes['Activity'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryGetActivityArgs, 'id'>
-  >;
-  getCities?: Resolver<
-    Array<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  getLatestActivities?: Resolver<
-    Array<ResolversTypes['Activity']>,
-    ParentType,
-    ContextType
-  >;
+export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+  getActivities?: Resolver<Array<ResolversTypes['Activity']>, ParentType, ContextType>;
+  getActivitiesByCity?: Resolver<Array<ResolversTypes['Activity']>, ParentType, ContextType, RequireFields<QueryGetActivitiesByCityArgs, 'city'>>;
+  getActivitiesByUser?: Resolver<Array<ResolversTypes['Activity']>, ParentType, ContextType>;
+  getActivity?: Resolver<ResolversTypes['Activity'], ParentType, ContextType, RequireFields<QueryGetActivityArgs, 'id'>>;
+  getCities?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  getLatestActivities?: Resolver<Array<ResolversTypes['Activity']>, ParentType, ContextType>;
   getMe?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
 };
 
-export type SignInDtoResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['SignInDto'] = ResolversParentTypes['SignInDto'],
-> = {
+export type SignInDtoResolvers<ContextType = any, ParentType extends ResolversParentTypes['SignInDto'] = ResolversParentTypes['SignInDto']> = {
   access_token?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type UserResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User'],
-> = {
+export type UserResolvers<ContextType = any, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = {
+  bookmarks?: Resolver<Array<ResolversTypes['Activity']>, ParentType, ContextType>;
   email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   firstName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -534,3 +380,4 @@ export type Resolvers<ContextType = any> = {
   SignInDto?: SignInDtoResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };
+

--- a/front-end/src/graphql/mutations/bookmark/addBookmark.ts
+++ b/front-end/src/graphql/mutations/bookmark/addBookmark.ts
@@ -1,13 +1,10 @@
 import ActivityFragment from '@/graphql/fragments/activity';
 import gql from 'graphql-tag';
 
-const GetUser = gql`
-  query GetUser {
-    getMe {
+const AddBookmark = gql`
+  mutation AddBookmark($activityId: ID!) {
+    addBookmark(activityId: $activityId) {
       id
-      firstName
-      lastName
-      email
       bookmarks {
         ...Activity
       }
@@ -16,4 +13,4 @@ const GetUser = gql`
   ${ActivityFragment}
 `;
 
-export default GetUser;
+export default AddBookmark;

--- a/front-end/src/graphql/mutations/bookmark/removeBookmark.ts
+++ b/front-end/src/graphql/mutations/bookmark/removeBookmark.ts
@@ -1,13 +1,10 @@
 import ActivityFragment from '@/graphql/fragments/activity';
 import gql from 'graphql-tag';
 
-const GetUser = gql`
-  query GetUser {
-    getMe {
+const RemoveBookmark = gql`
+  mutation RemoveBookmark($activityId: ID!) {
+    removeBookmark(activityId: $activityId) {
       id
-      firstName
-      lastName
-      email
       bookmarks {
         ...Activity
       }
@@ -16,4 +13,4 @@ const GetUser = gql`
   ${ActivityFragment}
 `;
 
-export default GetUser;
+export default RemoveBookmark;

--- a/front-end/src/graphql/mutations/bookmark/reorderBookmarks.ts
+++ b/front-end/src/graphql/mutations/bookmark/reorderBookmarks.ts
@@ -1,13 +1,10 @@
 import ActivityFragment from '@/graphql/fragments/activity';
 import gql from 'graphql-tag';
 
-const GetUser = gql`
-  query GetUser {
-    getMe {
+const ReorderBookmarks = gql`
+  mutation ReorderBookmarks($orderedIds: [ID!]!) {
+    reorderBookmarks(orderedIds: $orderedIds) {
       id
-      firstName
-      lastName
-      email
       bookmarks {
         ...Activity
       }
@@ -16,4 +13,4 @@ const GetUser = gql`
   ${ActivityFragment}
 `;
 
-export default GetUser;
+export default ReorderBookmarks;

--- a/front-end/src/graphql/schema.gql
+++ b/front-end/src/graphql/schema.gql
@@ -25,10 +25,13 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 scalar DateTime
 
 type Mutation {
+  addBookmark(activityId: ID!): User!
   createActivity(createActivityInput: CreateActivityInput!): Activity!
   login(signInInput: SignInInput!): SignInDto!
   logout: Boolean!
   register(signUpInput: SignUpInput!): User!
+  removeBookmark(activityId: ID!): User!
+  reorderBookmarks(orderedIds: [ID!]!): User!
 }
 
 type Query {
@@ -58,6 +61,7 @@ input SignUpInput {
 }
 
 type User {
+  bookmarks: [Activity!]!
   email: String!
   firstName: String!
   id: ID!

--- a/front-end/src/pages/profil.tsx
+++ b/front-end/src/pages/profil.tsx
@@ -1,19 +1,10 @@
-import { PageTitle } from '@/components';
-import { graphqlClient } from '@/graphql/apollo';
+import { BookmarksList, PageTitle } from '@/components';
 import { withAuth } from '@/hocs';
 import { useAuth } from '@/hooks';
-import { Avatar, Flex, Text } from '@mantine/core';
-import { GetServerSideProps } from 'next';
+import { Avatar, Flex, Stack, Text, Title } from '@mantine/core';
 import Head from 'next/head';
 
-interface ProfileProps {
-  favoriteActivities: {
-    id: string;
-    name: string;
-  }[];
-}
-
-const Profile = (props: ProfileProps) => {
+const Profile = () => {
   const { user } = useAuth();
 
   return (
@@ -22,17 +13,24 @@ const Profile = (props: ProfileProps) => {
         <title>Mon profil | CDTR</title>
       </Head>
       <PageTitle title="Mon profil" />
-      <Flex align="center" gap="md">
-        <Avatar color="cyan" radius="xl" size="lg">
-          {user?.firstName[0]}
-          {user?.lastName[0]}
-        </Avatar>
-        <Flex direction="column">
-          <Text>{user?.email}</Text>
-          <Text>{user?.firstName}</Text>
-          <Text>{user?.lastName}</Text>
+      <Stack spacing="xl">
+        <Flex align="center" gap="md">
+          <Avatar color="cyan" radius="xl" size="lg">
+            {user?.firstName[0]}
+            {user?.lastName[0]}
+          </Avatar>
+          <Flex direction="column">
+            <Text>{user?.email}</Text>
+            <Text>{user?.firstName}</Text>
+            <Text>{user?.lastName}</Text>
+          </Flex>
         </Flex>
-      </Flex>
+
+        <Stack spacing="md">
+          <Title order={3}>Mes favoris</Title>
+          <BookmarksList />
+        </Stack>
+      </Stack>
     </>
   );
 };

--- a/front-end/src/setupTests.ts
+++ b/front-end/src/setupTests.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom/extend-expect';
+
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  });
+}

--- a/front-end/vitest.config.ts
+++ b/front-end/vitest.config.ts
@@ -1,9 +1,15 @@
+import path from "path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     environment: "jsdom",
     dir: "./src",


### PR DESCRIPTION
Closes #19. Backend lives in #18 (already merged).

## Summary

- Adds a bookmark toggle (`BookmarkButton`) to `Activity` and `ActivityListItem`. Hidden when not signed in.
- Extends `GetUser` to include `bookmarks { ...Activity }` and exposes `refreshUser` from the auth context so mutations can sync local React state with the latest server payload.
- New `BookmarksList` component on `/profil` lists the user's bookmarks in stored order. Each row supports:
  - drag-and-drop reorder via `@dnd-kit/sortable` (with `KeyboardSensor` for accessibility),
  - up/down arrow buttons (disabled at list bounds),
  - quick removal via the existing `BookmarkButton`.
- Reorder is optimistic and rolls back on mutation failure.
- New mutations under `src/graphql/mutations/bookmark/` (add/remove/reorder).
- Vitest config now resolves `@/*` and `setupTests.ts` polyfills `window.matchMedia` (needed by Mantine in jsdom).

## Test plan

- [x] `npm run check`
- [x] `npm run lint` (no new warnings)
- [x] `npm run test -- --run` (14 passed; new BookmarkButton specs cover signed-out, add, remove)
- [x] `npm run build`
- [ ] Manual smoke (post-review):
  - Sign in, bookmark two activities on `/discover`, confirm icon flips and persists across reload.
  - On `/profil`, drag the second above the first, reload — order persists.
  - Use the up/down arrows, reload — order persists.
  - Remove a bookmark via the icon, confirm it disappears from `/profil`.
  - Sign out, confirm bookmark icons no longer render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bookmark controls added to activity items
  * New "Mes favoris" section on profile to view and manage bookmarks
  * Reorder bookmarks via drag-and-drop or up/down controls

* **Bug Fixes**
  * Bookmarks refresh immediately after add/remove actions
  * Error handling shows a snackbar message on mutation failures

* **Tests**
  * Unit tests for bookmark add/remove flows and auth refresh behavior

* **Chores**
  * Added drag-and-drop support and exported bookmark components for reuse
<!-- end of auto-generated comment: release notes by coderabbit.ai -->