### PR TITLE
feat(backend): admin debug mode mutation

### DIFF
--- a/back-end/schema.gql
+++ b/back-end/schema.gql
@@ -32,6 +32,7 @@ type Mutation {
   register(signUpInput: SignUpInput!): User!
   removeBookmark(activityId: ID!): User!
   reorderBookmarks(orderedIds: [ID!]!): User!
+  setDebugMode(enabled: Boolean!): User!
 }
 
 type Query {
@@ -62,9 +63,11 @@ input SignUpInput {
 
 type User {
   bookmarks: [Activity!]!
+  debugModeEnabled: Boolean!
   email: String!
   firstName: String!
   id: ID!
   lastName: String!
   password: String!
+  role: String!
 }

--- a/back-end/src/auth/admin.guard.spec.ts
+++ b/back-end/src/auth/admin.guard.spec.ts
@@ -1,0 +1,43 @@
+import {
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { AdminGuard } from './admin.guard';
+
+const buildContext = (
+  jwtPayload: { role?: string } | null,
+): ExecutionContext => {
+  const gqlCtx = { jwtPayload };
+  jest.spyOn(GqlExecutionContext, 'create').mockReturnValue({
+    getContext: () => gqlCtx,
+  } as unknown as GqlExecutionContext);
+  return {} as ExecutionContext;
+};
+
+describe('AdminGuard', () => {
+  const guard = new AdminGuard();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws Unauthorized when no jwt payload is present', async () => {
+    await expect(guard.canActivate(buildContext(null))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws Forbidden when role is not admin', async () => {
+    await expect(
+      guard.canActivate(buildContext({ role: 'user' })),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows access when role is admin', async () => {
+    await expect(
+      guard.canActivate(buildContext({ role: 'admin' })),
+    ).resolves.toBe(true);
+  });
+});

--- a/back-end/src/auth/admin.guard.ts
+++ b/back-end/src/auth/admin.guard.ts
@@ -1,0 +1,21 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const gqlContext = GqlExecutionContext.create(context);
+    const ctx = gqlContext.getContext();
+
+    if (!ctx.jwtPayload) throw new UnauthorizedException();
+    if (ctx.jwtPayload.role !== 'admin') throw new ForbiddenException();
+
+    return true;
+  }
+}

--- a/back-end/src/auth/auth.service.ts
+++ b/back-end/src/auth/auth.service.ts
@@ -37,6 +37,7 @@ export class AuthService {
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
+      role: user.role,
     };
     return await this.jwtService.signAsync(payload);
   }

--- a/back-end/src/auth/types/jwtPayload.dto.ts
+++ b/back-end/src/auth/types/jwtPayload.dto.ts
@@ -3,4 +3,5 @@ export type PayloadDto = {
   email: string;
   firstName: string;
   lastName: string;
+  role: 'user' | 'admin';
 };

--- a/back-end/src/me/resolver/me.resolver.spec.ts
+++ b/back-end/src/me/resolver/me.resolver.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MeResolver } from './me.resolver';
+import { UserService } from '../../user/user.service';
+import { ContextWithJWTPayload } from '../../auth/types/context';
+
+describe('MeResolver', () => {
+  let resolver: MeResolver;
+  let userService: { setDebugMode: jest.Mock; getById: jest.Mock };
+
+  const context = {
+    jwtPayload: { id: 'user-1', role: 'admin' },
+  } as unknown as ContextWithJWTPayload;
+
+  beforeEach(async () => {
+    userService = {
+      setDebugMode: jest
+        .fn()
+        .mockResolvedValue({ id: 'user-1', debugModeEnabled: true }),
+      getById: jest.fn().mockResolvedValue({ id: 'user-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MeResolver, { provide: UserService, useValue: userService }],
+    }).compile();
+
+    resolver = module.get(MeResolver);
+  });
+
+  it('setDebugMode forwards user id and enabled value', async () => {
+    await resolver.setDebugMode(context, true);
+    expect(userService.setDebugMode).toHaveBeenCalledWith({
+      userId: 'user-1',
+      enabled: true,
+    });
+  });
+});

--- a/back-end/src/me/resolver/me.resolver.ts
+++ b/back-end/src/me/resolver/me.resolver.ts
@@ -1,7 +1,8 @@
-import { Context, Query, Resolver } from '@nestjs/graphql';
+import { Args, Context, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UserService } from '../../user/user.service';
 import { UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../../auth/auth.guard';
+import { AdminGuard } from '../../auth/admin.guard';
 import { User } from 'src/user/user.schema';
 import { ContextWithJWTPayload } from 'src/auth/types/context';
 
@@ -15,5 +16,17 @@ export class MeResolver {
     // the AuthGard will add the user to the context
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this.userService.getById(context.jwtPayload.id);
+  }
+
+  @Mutation(() => User)
+  @UseGuards(AuthGuard, AdminGuard)
+  async setDebugMode(
+    @Context() context: ContextWithJWTPayload,
+    @Args('enabled') enabled: boolean,
+  ): Promise<User> {
+    return this.userService.setDebugMode({
+      userId: context.jwtPayload.id,
+      enabled,
+    });
   }
 }

--- a/back-end/src/user/user.schema.ts
+++ b/back-end/src/user/user.schema.ts
@@ -8,8 +8,13 @@ export class User extends Document {
   @Field(() => ID)
   id!: string;
 
+  @Field()
   @Prop({ required: true, enum: ['user', 'admin'], default: 'user' })
   role!: 'user' | 'admin';
+
+  @Field()
+  @Prop({ default: false })
+  debugModeEnabled!: boolean;
 
   @Field()
   @Prop({ required: true })

--- a/back-end/src/user/user.service.spec.ts
+++ b/back-end/src/user/user.service.spec.ts
@@ -146,6 +146,22 @@ describe('UserService', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
+    it('setDebugMode toggles the persisted debugModeEnabled field', async () => {
+      const user = await createUser();
+
+      const enabled = await userService.setDebugMode({
+        userId: user.id,
+        enabled: true,
+      });
+      expect(enabled.debugModeEnabled).toBe(true);
+
+      const disabled = await userService.setDebugMode({
+        userId: user.id,
+        enabled: false,
+      });
+      expect(disabled.debugModeEnabled).toBe(false);
+    });
+
     it('reorderBookmarks rejects a different set', async () => {
       const user = await createUser();
       const a = await createActivity(user.id);


### PR DESCRIPTION
Closes #22.

## Summary

- Declares `debugModeEnabled` on the `User` schema. `UserService.setDebugMode` already existed but wrote to an undeclared field, which Mongoose silently dropped.
- Exposes `role` on the `User` GraphQL type and rides `role` through the JWT payload so guards can authorize without an extra DB lookup.
- Adds `AdminGuard` (`back-end/src/auth/admin.guard.ts`) — mirrors `AuthGuard`, throws `UnauthorizedException` if there's no payload and `ForbiddenException` if `role !== 'admin'`.
- Wires `setDebugMode(enabled: Boolean!): User` on `MeResolver` with `@UseGuards(AuthGuard, AdminGuard)`.

## Test plan

- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test` (20 passing — adds `setDebugMode` service coverage, `AdminGuard` unit specs, and a `MeResolver` delegation test)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added debug mode toggle functionality for user accounts
  * Introduced role-based user system supporting admin and standard user roles
  * User profiles now display role and debug mode status information

* **Tests**
  * Added test coverage for debug mode management and authorization features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->