### PR TITLE
security(backend): remove password from GraphQL User type (#26)

### DIFF
--- a/back-end/schema.gql
+++ b/back-end/schema.gql
@@ -68,6 +68,5 @@ type User {
   firstName: String!
   id: ID!
   lastName: String!
-  password: String!
   role: String!
 }

--- a/back-end/src/user/user.schema.ts
+++ b/back-end/src/user/user.schema.ts
@@ -28,7 +28,6 @@ export class User extends Document {
   @Prop({ required: true, unique: true })
   email!: string;
 
-  @Field()
   @Prop({ required: true })
   password!: string;
 

--- a/front-end/src/graphql/generated/types.ts
+++ b/front-end/src/graphql/generated/types.ts
@@ -131,7 +131,6 @@ export type User = {
   firstName: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   lastName: Scalars['String']['output'];
-  password: Scalars['String']['output'];
   role: Scalars['String']['output'];
 };
 
@@ -385,7 +384,6 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
   firstName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   lastName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  password?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   role?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/front-end/src/graphql/schema.gql
+++ b/front-end/src/graphql/schema.gql
@@ -68,6 +68,5 @@ type User {
   firstName: String!
   id: ID!
   lastName: String!
-  password: String!
   role: String!
 }


### PR DESCRIPTION
Closes #26

## Summary
- Drop `@Field()` from `User.password` in `back-end/src/user/user.schema.ts` so the bcrypt hash is no longer queryable or introspectable via GraphQL.
- Mongoose `@Prop` is kept — auth (login/register/bcrypt compare) is unchanged.
- Regenerate `back-end/schema.gql` and `front-end/src/graphql/{schema.gql,generated/types.ts}`.

## Test plan
- [x] `cd back-end && npm run check && npm run lint && npm test && npm run build`
- [x] `cd front-end && npm run generate-types && npm run check && npm run lint && npm test -- --run && npm run build`
- [x] Verified `type User` in both `schema.gql` files no longer contains `password`; `SignInInput` / `SignUpInput` still accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password field is no longer exposed in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->