### PR TITLE
security(backend): escape user input in findByCity regex (#29)

### DIFF
--- a/back-end/src/activity/activity.service.spec.ts
+++ b/back-end/src/activity/activity.service.spec.ts
@@ -1,9 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
 import { ActivityService } from './activity.service';
 import { ActivityModule } from './activity.module';
+import { Activity } from './activity.schema';
 import { TestModule, closeInMongodConnection } from 'src/test/test.module';
+
 describe('ActivityService', () => {
   let service: ActivityService;
+  let activityModel: Model<Activity>;
   let module: TestingModule;
 
   beforeAll(async () => {
@@ -12,6 +17,7 @@ describe('ActivityService', () => {
     }).compile();
 
     service = module.get<ActivityService>(ActivityService);
+    activityModel = module.get<Model<Activity>>(getModelToken(Activity.name));
   });
 
   afterAll(async () => {
@@ -23,5 +29,45 @@ describe('ActivityService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('findByCity', () => {
+    const ownerId = new Types.ObjectId();
+
+    beforeAll(async () => {
+      await activityModel.insertMany([
+        {
+          name: 'Tour Eiffel',
+          city: 'Paris',
+          description: 'iconic',
+          price: 10,
+          owner: ownerId,
+        },
+        {
+          name: 'a.b literal',
+          city: 'Paris',
+          description: 'has a literal dot',
+          price: 10,
+          owner: ownerId,
+        },
+        {
+          name: 'aXb regex bait',
+          city: 'Paris',
+          description: 'would match `a.b` regex',
+          price: 10,
+          owner: ownerId,
+        },
+      ]);
+    });
+
+    afterAll(async () => {
+      await activityModel.deleteMany({});
+    });
+
+    it('treats regex metacharacters in user input as literals', async () => {
+      const results = await service.findByCity('Paris', 'a.b');
+      const names = results.map((a) => a.name).sort();
+      expect(names).toEqual(['a.b literal']);
+    });
   });
 });

--- a/back-end/src/activity/activity.service.ts
+++ b/back-end/src/activity/activity.service.ts
@@ -4,6 +4,9 @@ import { Model } from 'mongoose';
 import { Activity } from './activity.schema';
 import { CreateActivityInput } from './activity.inputs.dto';
 
+const escapeRegex = (input: string): string =>
+  input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 @Injectable()
 export class ActivityService {
   constructor(
@@ -58,7 +61,9 @@ export class ActivityService {
         $and: [
           { city },
           ...(price ? [{ price }] : []),
-          ...(activity ? [{ name: { $regex: activity, $options: 'i' } }] : []),
+          ...(activity
+            ? [{ name: { $regex: escapeRegex(activity), $options: 'i' } }]
+            : []),
         ],
       })
       .exec();


### PR DESCRIPTION
Closes #29

## Summary
- Add an `escapeRegex` helper in `back-end/src/activity/activity.service.ts` and route the `activity` query parameter through it before it reaches `\$regex` in `findByCity`.
- Closes the ReDoS / regex-injection surface flagged in #29 — crafted inputs like `(a+)+\$` or `.*` can no longer pin Mongo CPU or break expected match semantics.
- Unit test covers literal metacharacters: `'a.b'` matches only `'a.b literal'`, not `'aXb regex bait'`.

## Test plan
- [x] `cd back-end && npm run check && npm run lint && npm test && npm run build`
- [x] New spec `findByCity > treats regex metacharacters in user input as literals` passes against an in-memory Mongo seeded with three Paris activities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search accuracy for activities by city. Search queries containing special characters (such as periods, asterisks, and plus signs) are now correctly treated as literal text instead of regex patterns, ensuring accurate results when searching for activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->