### PR TITLE
security: cookie-only JWT auth — harden cookie + drop localStorage (#27, #30)

### DIFF
--- a/back-end/src/auth/auth.resolver.ts
+++ b/back-end/src/auth/auth.resolver.ts
@@ -1,7 +1,17 @@
 import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
+import { CookieOptions } from 'express';
 import { SignInDto, SignInInput, SignUpInput } from './types';
 import { AuthService } from './auth.service';
 import { User } from 'src/user/user.schema';
+
+const buildJwtCookieOptions = (): CookieOptions => ({
+  httpOnly: true,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax',
+  ...(process.env.FRONTEND_DOMAIN && process.env.FRONTEND_DOMAIN !== 'localhost'
+    ? { domain: process.env.FRONTEND_DOMAIN }
+    : {}),
+});
 
 @Resolver('Auth')
 export class AuthResolver {
@@ -13,13 +23,7 @@ export class AuthResolver {
     @Context() ctx: any,
   ): Promise<SignInDto> {
     const data = await this.authService.signIn(loginUserDto);
-    ctx.res.cookie('jwt', data.access_token, {
-      httpOnly: true,
-      ...(process.env.FRONTEND_DOMAIN !== 'localhost'
-        ? { domain: process.env.FRONTEND_DOMAIN }
-        : {}),
-    });
-
+    ctx.res.cookie('jwt', data.access_token, buildJwtCookieOptions());
     return data;
   }
 
@@ -32,12 +36,7 @@ export class AuthResolver {
 
   @Mutation(() => Boolean)
   async logout(@Context() ctx: any): Promise<boolean> {
-    ctx.res.clearCookie('jwt', {
-      httpOnly: true,
-      ...(process.env.FRONTEND_DOMAIN !== 'localhost'
-        ? { domain: process.env.FRONTEND_DOMAIN }
-        : {}),
-    });
+    ctx.res.clearCookie('jwt', buildJwtCookieOptions());
     return true;
   }
 }

--- a/front-end/src/contexts/authContext.tsx
+++ b/front-end/src/contexts/authContext.tsx
@@ -59,6 +59,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     }
     getUser()
       .then((res) => setUser(res.data?.getMe || null))
+      .catch(() => setUser(null))
       .finally(() => setIsLoading(false));
   }, [user]);
 

--- a/front-end/src/contexts/authContext.tsx
+++ b/front-end/src/contexts/authContext.tsx
@@ -53,23 +53,19 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [logout] = useMutation<LogoutMutation, LogoutMutationVariables>(Logout);
 
   useEffect(() => {
-    const token = localStorage.getItem('token');
-
-    if (!user && token) {
-      getUser()
-        .then((res) => setUser(res.data?.getMe || null))
-        .finally(() => setIsLoading(false));
-    } else {
+    if (user) {
       setIsLoading(false);
+      return;
     }
+    getUser()
+      .then((res) => setUser(res.data?.getMe || null))
+      .finally(() => setIsLoading(false));
   }, [user]);
 
   const handleSignin = async (input: SignInInput) => {
     try {
       setIsLoading(true);
-      const response = await signin({ variables: { signInInput: input } });
-      const token = response.data?.login?.access_token || '';
-      localStorage.setItem('token', token);
+      await signin({ variables: { signInInput: input } });
       await getUser().then((res) => setUser(res.data?.getMe || null));
       router.push('/profil');
     } catch (err) {
@@ -95,7 +91,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     try {
       setIsLoading(true);
       await logout();
-      localStorage.removeItem('token');
       setUser(null);
       router.push('/');
     } catch (err) {


### PR DESCRIPTION
Closes #27, closes #30

These two issues are coupled: #30 makes the httpOnly cookie the sole source of truth for auth, so it has to be #27-hardened in the same change.

## Summary
- **Backend (#27)** — `back-end/src/auth/auth.resolver.ts`: extract a `buildJwtCookieOptions()` helper used by both `login` (`cookie`) and `logout` (`clearCookie`). Add:
  - `secure: process.env.NODE_ENV === 'production'`
  - `sameSite: 'lax'`
- **Frontend (#30)** — `front-end/src/contexts/authContext.tsx`: remove all `localStorage` reads/writes for the JWT.
  - Mount: call `getMe` unconditionally; null/error means logged-out.
  - `handleSignin`: no longer pulls `access_token` from the response — relies on the httpOnly cookie set by the backend.
  - `handleLogout`: no client-side token clearing — backend `clearCookie` is sufficient.

## Test plan
- [x] `cd back-end && npm run check && npm run lint && npm test && npm run build`
- [x] `cd front-end && npm run check && npm run lint && npm test -- --run && npm run build`
- [ ] Manual browser smoke: login → reload → still authenticated; logout → cookie cleared, `getMe` returns null; SSR-authenticated pages (`/my-activities`, `/activities/[id]`) still work via cookie forwarding.
- [ ] Devtools: `Set-Cookie` header on `login` includes `HttpOnly; SameSite=Lax` (and `Secure` in a prod-like build).

## Notes
- The `login` mutation still returns `access_token` in the response shape — it's no longer consumed by the frontend, but removing it from the GraphQL schema is an API change worth its own PR.
- `process.env.FRONTEND_DOMAIN` guard tightened to also skip when the var is unset (previous code passed `domain: undefined` only via the `'localhost'` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT cookie handling: httpOnly, secure in production, sameSite=lax, and safer domain handling when applicable.
  * Logout now reliably clears the authentication cookie.

* **Refactor**
  * Removed persistence of access tokens in local storage.
  * Auth initialization always refreshes user state when missing and sets loading state appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->