### PR TITLE
security(backend): rate-limit auth mutations (#28)

### DIFF
--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/jwt": "^10.1.0",
         "@nestjs/mongoose": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/throttler": "^5.2.0",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-transformer-validator": "^0.9.1",
@@ -2646,6 +2647,17 @@
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-5.2.0.tgz",
+      "integrity": "sha512-G/G/MV3xf6sy1DwmnJsgeL+d2tQ/xGRNa9ZhZjm9Kyxp+3+ylGzwJtcnhWlN82PMEp3TiDQpTt+9waOIg/bpPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -35,6 +35,7 @@
     "@nestjs/jwt": "^10.1.0",
     "@nestjs/mongoose": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/throttler": "^5.2.0",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-transformer-validator": "^0.9.1",

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -1,10 +1,13 @@
 import { Module, UnauthorizedException } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ActivityModule } from './activity/activity.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { GqlThrottlerGuard } from './auth/gql-throttler.guard';
 import { MeModule } from './me/me.module';
 import { SeedModule } from './seed/seed.module';
 import { SeedService } from './seed/seed.service';
@@ -18,6 +21,7 @@ import { PayloadDto } from './auth/types/jwtPayload.dto';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 10 }]),
     GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
       imports: [JwtModule],
@@ -63,7 +67,11 @@ import { PayloadDto } from './auth/types/jwtPayload.dto';
     SeedModule,
   ],
   controllers: [AppController],
-  providers: [AppService, SeedService],
+  providers: [
+    AppService,
+    SeedService,
+    { provide: APP_GUARD, useClass: GqlThrottlerGuard },
+  ],
 })
 export class BaseAppModule {}
 

--- a/back-end/src/auth/auth.resolver.ts
+++ b/back-end/src/auth/auth.resolver.ts
@@ -1,8 +1,11 @@
 import { Resolver, Mutation, Args, Context } from '@nestjs/graphql';
+import { Throttle } from '@nestjs/throttler';
 import { CookieOptions } from 'express';
 import { SignInDto, SignInInput, SignUpInput } from './types';
 import { AuthService } from './auth.service';
 import { User } from 'src/user/user.schema';
+
+const AUTH_THROTTLE = { default: { ttl: 60_000, limit: 5 } };
 
 const buildJwtCookieOptions = (): CookieOptions => ({
   httpOnly: true,
@@ -17,6 +20,7 @@ const buildJwtCookieOptions = (): CookieOptions => ({
 export class AuthResolver {
   constructor(private authService: AuthService) {}
 
+  @Throttle(AUTH_THROTTLE)
   @Mutation(() => SignInDto)
   async login(
     @Args('signInInput') loginUserDto: SignInInput,
@@ -27,6 +31,7 @@ export class AuthResolver {
     return data;
   }
 
+  @Throttle(AUTH_THROTTLE)
   @Mutation(() => User)
   async register(
     @Args('signUpInput') createUserDto: SignUpInput,

--- a/back-end/src/auth/auth.throttle.e2e.spec.ts
+++ b/back-end/src/auth/auth.throttle.e2e.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import * as request from 'supertest';
+import { BaseAppModule } from '../app.module';
+import { TestModule, closeInMongodConnection } from '../test/test.module';
+
+describe('Auth throttling', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule, BaseAppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await closeInMongodConnection();
+  });
+
+  it('rate-limits the login mutation past the per-IP limit', async () => {
+    const loginMutation = `
+      mutation {
+        login(signInInput:{ email: "${randomUUID()}@test.com", password: "wrong" }) {
+          access_token
+        }
+      }
+    `;
+
+    const responses = [];
+    for (let i = 0; i < 7; i++) {
+      const res = await request(app.getHttpServer())
+        .post('/graphql')
+        .send({ query: loginMutation });
+      responses.push(res);
+    }
+
+    const throttled = responses.filter((r) =>
+      JSON.stringify(r.body).includes('ThrottlerException'),
+    );
+
+    expect(throttled.length).toBeGreaterThan(0);
+  });
+});

--- a/back-end/src/auth/gql-throttler.guard.ts
+++ b/back-end/src/auth/gql-throttler.guard.ts
@@ -1,0 +1,18 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { Request, Response } from 'express';
+
+@Injectable()
+export class GqlThrottlerGuard extends ThrottlerGuard {
+  getRequestResponse(context: ExecutionContext): {
+    req: Request;
+    res: Response;
+  } {
+    const gqlCtx = GqlExecutionContext.create(context).getContext<{
+      req: Request;
+      res: Response;
+    }>();
+    return { req: gqlCtx.req, res: gqlCtx.res };
+  }
+}


### PR DESCRIPTION
Closes #28

## Summary
- Add `@nestjs/throttler@^5` and register `ThrottlerModule.forRoot([{ ttl: 60_000, limit: 10 }])` as a global default in `BaseAppModule`.
- Custom `GqlThrottlerGuard` (`back-end/src/auth/gql-throttler.guard.ts`) overrides `getRequestResponse` so the throttler can pull `req`/`res` out of the GraphQL execution context, then wired globally via `APP_GUARD`.
- Apply a stricter `@Throttle({ default: { ttl: 60_000, limit: 5 } })` override on `login` and `register` in `back-end/src/auth/auth.resolver.ts`.

## Test plan
- [x] `cd back-end && npm run check && npm run lint && npm test && npm run build`
- [x] New e2e: `auth.throttle.e2e.spec.ts` fires 7 sequential `login` mutations from the same IP and asserts at least one comes back as `ThrottlerException: Too Many Requests`.
- [x] Existing `app.e2e.spec.ts` (register → login → getMe in same suite) still passes — single calls per route stay well under the 5/min override.

## Notes
- Limits are deliberately loose (5/min on auth, 10/min globally) — easy to tighten later, and they don't impact local dev or normal test runs.
- The 70 npm-audit warnings reported during install are transitive issues already present in the lockfile, not introduced by `@nestjs/throttler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented global request rate limiting on the platform.
  * Login and register endpoints now enforce stricter rate limits per IP address.

* **Tests**
  * Added end-to-end tests for throttling behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->