### PR TITLE
perf(backend): batch Activity.owner with DataLoader (#31)

### DIFF
--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -25,6 +25,7 @@
         "class-transformer-validator": "^0.9.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
+        "dataloader": "^2.2.3",
         "graphql": "^16.8.1",
         "mongoose": "^7.3.4",
         "reflect-metadata": "^0.1.13",
@@ -5003,6 +5004,12 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
+    "node_modules/dataloader": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -41,6 +41,7 @@
     "class-transformer-validator": "^0.9.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
+    "dataloader": "^2.2.3",
     "graphql": "^16.8.1",
     "mongoose": "^7.3.4",
     "reflect-metadata": "^0.1.13",

--- a/back-end/src/activity/activity.module.ts
+++ b/back-end/src/activity/activity.module.ts
@@ -4,7 +4,6 @@ import { AuthModule } from 'src/auth/auth.module';
 import { ActivityService } from './activity.service';
 import { Activity, ActivitySchema } from './activity.schema';
 import { ActivityResolver } from './activity.resolver';
-import { UserModule } from 'src/user/user.module';
 
 @Module({
   imports: [
@@ -12,7 +11,6 @@ import { UserModule } from 'src/user/user.module';
       { name: Activity.name, schema: ActivitySchema },
     ]),
     AuthModule,
-    UserModule,
   ],
   exports: [ActivityService],
   providers: [ActivityService, ActivityResolver],

--- a/back-end/src/activity/activity.resolver.ts
+++ b/back-end/src/activity/activity.resolver.ts
@@ -12,7 +12,6 @@ import {
 import { UseGuards } from '@nestjs/common';
 import { ActivityService } from './activity.service';
 import { AuthGuard } from 'src/auth/auth.guard';
-import { UserService } from 'src/user/user.service';
 import { Activity } from './activity.schema';
 
 import { CreateActivityInput } from './activity.inputs.dto';
@@ -21,10 +20,7 @@ import { ContextWithJWTPayload } from 'src/auth/types/context';
 
 @Resolver(() => Activity)
 export class ActivityResolver {
-  constructor(
-    private readonly activityService: ActivityService,
-    private readonly userServices: UserService,
-  ) {}
+  constructor(private readonly activityService: ActivityService) {}
 
   @ResolveField(() => ID)
   id(@Parent() activity: Activity): string {
@@ -32,9 +28,11 @@ export class ActivityResolver {
   }
 
   @ResolveField(() => User)
-  async owner(@Parent() activity: Activity): Promise<User> {
-    await activity.populate('owner');
-    return activity.owner;
+  async owner(
+    @Parent() activity: Activity,
+    @Context() context: ContextWithJWTPayload,
+  ): Promise<User> {
+    return context.loaders.userById.load(String(activity.owner));
   }
 
   @Query(() => [Activity])

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -17,6 +17,8 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { Request, Response } from 'express';
 import { PayloadDto } from './auth/types/jwtPayload.dto';
+import { UserService } from './user/user.service';
+import { createLoaders } from './graphql/loaders';
 
 @Module({
   imports: [
@@ -24,11 +26,12 @@ import { PayloadDto } from './auth/types/jwtPayload.dto';
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 10 }]),
     GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
-      imports: [JwtModule],
-      inject: [JwtService, ConfigService],
+      imports: [JwtModule, UserModule],
+      inject: [JwtService, ConfigService, UserService],
       useFactory: async (
         jwtService: JwtService,
         configService: ConfigService,
+        userService: UserService,
       ) => {
         const secret = configService.get<string>('JWT_SECRET');
         return {
@@ -53,6 +56,7 @@ import { PayloadDto } from './auth/types/jwtPayload.dto';
 
             return {
               jwtPayload,
+              loaders: createLoaders(userService),
               req,
               res,
             };

--- a/back-end/src/auth/types/context.ts
+++ b/back-end/src/auth/types/context.ts
@@ -1,6 +1,8 @@
 import { PayloadDto } from './jwtPayload.dto';
+import { GraphQLLoaders } from 'src/graphql/loaders';
 
 export interface ContextWithJWTPayload {
   jwtPayload: PayloadDto;
+  loaders: GraphQLLoaders;
   // Add other properties you expect in the context here
 }

--- a/back-end/src/graphql/loaders.spec.ts
+++ b/back-end/src/graphql/loaders.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Model } from 'mongoose';
+import { randomUUID } from 'crypto';
+import { UserService } from 'src/user/user.service';
+import { UserModule } from 'src/user/user.module';
+import { TestModule, closeInMongodConnection } from 'src/test/test.module';
+import { User } from 'src/user/user.schema';
+import { getModelToken } from '@nestjs/mongoose';
+import { createLoaders } from './loaders';
+
+describe('createLoaders.userById', () => {
+  let userService: UserService;
+  let module: TestingModule;
+
+  const createUser = () =>
+    userService.createUser({
+      email: randomUUID() + '@test.com',
+      password: 'password',
+      firstName: 'first',
+      lastName: 'last',
+    });
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [TestModule, UserModule],
+    }).compile();
+
+    userService = module.get<UserService>(UserService);
+  });
+
+  afterAll(async () => {
+    if (module) {
+      await module.close();
+    }
+    await closeInMongodConnection();
+  });
+
+  it('batches N parallel loads into a single DB query', async () => {
+    const users = await Promise.all([createUser(), createUser(), createUser()]);
+    const userModel = module.get<Model<User>>(getModelToken(User.name));
+    const findSpy = jest.spyOn(userModel, 'find');
+
+    const loaders = createLoaders(userService);
+    const results = await Promise.all(
+      users.map((u) => loaders.userById.load(u.id)),
+    );
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(results.map((u) => u.id)).toEqual(users.map((u) => u.id));
+    findSpy.mockRestore();
+  });
+
+  it('caches repeated loads for the same id', async () => {
+    const user = await createUser();
+    const userModel = module.get<Model<User>>(getModelToken(User.name));
+    const findSpy = jest.spyOn(userModel, 'find');
+
+    const loaders = createLoaders(userService);
+    await loaders.userById.load(user.id);
+    await loaders.userById.load(user.id);
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    findSpy.mockRestore();
+  });
+});

--- a/back-end/src/graphql/loaders.spec.ts
+++ b/back-end/src/graphql/loaders.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { Model } from 'mongoose';
+import { NotFoundException } from '@nestjs/common';
+import { Model, Types } from 'mongoose';
 import { randomUUID } from 'crypto';
 import { UserService } from 'src/user/user.service';
 import { UserModule } from 'src/user/user.module';
@@ -48,6 +49,15 @@ describe('createLoaders.userById', () => {
     expect(findSpy).toHaveBeenCalledTimes(1);
     expect(results.map((u) => u.id)).toEqual(users.map((u) => u.id));
     findSpy.mockRestore();
+  });
+
+  it('rejects with NotFoundException when the id does not exist', async () => {
+    const loaders = createLoaders(userService);
+    const missingId = new Types.ObjectId().toString();
+
+    await expect(loaders.userById.load(missingId)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 
   it('caches repeated loads for the same id', async () => {

--- a/back-end/src/graphql/loaders.ts
+++ b/back-end/src/graphql/loaders.ts
@@ -1,0 +1,19 @@
+import DataLoader = require('dataloader');
+import { NotFoundException } from '@nestjs/common';
+import { UserService } from 'src/user/user.service';
+import { User } from 'src/user/user.schema';
+
+export interface GraphQLLoaders {
+  userById: DataLoader<string, User>;
+}
+
+export function createLoaders(userService: UserService): GraphQLLoaders {
+  return {
+    userById: new DataLoader<string, User>(async (ids) => {
+      const users = await userService.findManyByIds(ids);
+      return users.map(
+        (user, i) => user ?? new NotFoundException(`User ${ids[i]} not found`),
+      );
+    }),
+  };
+}

--- a/back-end/src/user/user.service.spec.ts
+++ b/back-end/src/user/user.service.spec.ts
@@ -161,7 +161,44 @@ describe('UserService', () => {
       });
       expect(disabled.debugModeEnabled).toBe(false);
     });
+  });
 
+  describe('findManyByIds', () => {
+    it('returns users in the same order as input ids, with null for missing', async () => {
+      const a = await createUser();
+      const b = await createUser();
+      const missing = new Types.ObjectId().toString();
+
+      const result = await userService.findManyByIds([b.id, missing, a.id]);
+
+      expect(result.map((u) => u?.id ?? null)).toEqual([b.id, null, a.id]);
+    });
+
+    it('issues a single find query for N ids', async () => {
+      const a = await createUser();
+      const b = await createUser();
+      const c = await createUser();
+
+      const userModel = userService['userModel'] as Model<unknown>;
+      const findSpy = jest.spyOn(userModel, 'find');
+
+      await userService.findManyByIds([a.id, b.id, c.id]);
+
+      expect(findSpy).toHaveBeenCalledTimes(1);
+      findSpy.mockRestore();
+    });
+
+    it('skips invalid ids without throwing', async () => {
+      const a = await createUser();
+
+      const result = await userService.findManyByIds(['not-an-id', a.id]);
+
+      expect(result[0]).toBeNull();
+      expect(result[1]?.id).toBe(a.id);
+    });
+  });
+
+  describe('bookmarks (cont.)', () => {
     it('reorderBookmarks rejects a different set', async () => {
       const user = await createUser();
       const a = await createActivity(user.id);

--- a/back-end/src/user/user.service.ts
+++ b/back-end/src/user/user.service.ts
@@ -47,12 +47,20 @@ export class UserService {
   }
 
   async findManyByIds(ids: readonly string[]): Promise<(User | null)[]> {
-    const validIds = ids.filter((id) => Types.ObjectId.isValid(id));
+    const canonicalIds = ids.map((id) =>
+      Types.ObjectId.isValid(id) ? new Types.ObjectId(id).toString() : null,
+    );
+    const validObjectIds = canonicalIds
+      .filter((id): id is string => id !== null)
+      .map((id) => new Types.ObjectId(id));
+    if (validObjectIds.length === 0) {
+      return ids.map(() => null);
+    }
     const users = await this.userModel
-      .find({ _id: { $in: validIds.map((id) => new Types.ObjectId(id)) } })
+      .find({ _id: { $in: validObjectIds } })
       .exec();
     const byId = new Map(users.map((user) => [String(user._id), user]));
-    return ids.map((id) => byId.get(id) ?? null);
+    return canonicalIds.map((id) => (id ? byId.get(id) ?? null : null));
   }
 
   async createUser(

--- a/back-end/src/user/user.service.ts
+++ b/back-end/src/user/user.service.ts
@@ -46,6 +46,15 @@ export class UserService {
     return user;
   }
 
+  async findManyByIds(ids: readonly string[]): Promise<(User | null)[]> {
+    const validIds = ids.filter((id) => Types.ObjectId.isValid(id));
+    const users = await this.userModel
+      .find({ _id: { $in: validIds.map((id) => new Types.ObjectId(id)) } })
+      .exec();
+    const byId = new Map(users.map((user) => [String(user._id), user]));
+    return ids.map((id) => byId.get(id) ?? null);
+  }
+
   async createUser(
     data: SignUpInput & {
       role?: User['role'];


### PR DESCRIPTION
## Summary
- Add per-request `userById` DataLoader; `Activity.owner` now batches into one `User.find({ _id: { $in: [...] } })` instead of N populate() calls.
- New `UserService.findManyByIds(ids)` returns users in the same order as input, with `null` for missing/invalid ids.
- Loaders wired into the GraphQL context factory (`app.module.ts`); `ContextWithJWTPayload` extended with `loaders`.

Closes #31.

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test` (27/27, includes new `loaders.spec.ts` asserting 1 query for N parallel loads + per-request caching)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled GraphQL data loading to use batched, cached user lookups for more efficient queries.
  * Updated activity resolution to use the new loader-based approach.

* **New Features**
  * GraphQL request context now provides per-request data loaders for user fetching.

* **Tests**
  * Added tests for batched user queries and loader caching/ordering.

* **Chores**
  * Added a data loader dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->