### PR TITLE
ops(backend): gate seed behind SEED_ON_BOOT (#33)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@
 - Local DB helpers: `npm run start:db`, `npm run stop:db`, `npm run stop:db:rm` delegate to the root `compose.yaml` MongoDB service. Root equivalents also exist via `make db-up`, `make db-down`, and `make db-reset`.
 - Read-only checks: `npm run check`, `npm run lint`, `npm test -- --runTestsByPath <path-to-spec>`, `npm run build`.
 - `npm run lint:fix` runs ESLint with `--fix` and can modify files; use it as an explicit mutating cleanup command.
-- Required env is documented in `.env.dist`: `MONGO_URI`, `JWT_SECRET`, `JWT_EXPIRATION_TIME`, `FRONTEND_DOMAIN`, `FRONTEND_URL`.
+- Required env is documented in `.env.dist`: `MONGO_URI`, `JWT_SECRET`, `JWT_EXPIRATION_TIME`, `FRONTEND_DOMAIN`, `FRONTEND_URL`. `SEED_ON_BOOT` is optional (defaults to `false`; only `true`/`false` accepted).
 - `src/main.ts` sets a global REST prefix of `/api`, but GraphQL requests still go to `/graphql`.
 - GraphQL schema is auto-generated to `schema.gql`; playground is enabled in `src/app.module.ts`.
 - Auth context accepts either a `jwt` header or the `jwt` cookie. `login` and `logout` set or clear that cookie in `src/auth/auth.resolver.ts`.
-- The app seeds data on every bootstrap through `AppService.onApplicationBootstrap() -> SeedService.execute()`. The seed is idempotent for the bundled default users, but starting the backend is not a "no side effects" action.
+- Seeding is gated on the `SEED_ON_BOOT` env var (default `false`). When set to `true`, `AppService.onApplicationBootstrap()` calls `SeedService.execute()`. The seed is idempotent for the bundled default users.
 
 ## Verification
 

--- a/back-end/.env.dist
+++ b/back-end/.env.dist
@@ -11,3 +11,8 @@ FRONTEND_URL=http://localhost:3001
 
 # Server
 PORT=3000
+
+# Seed
+# When "true", runs SeedService.execute() on application bootstrap.
+# Defaults to "false"; only "true"/"false" are accepted.
+SEED_ON_BOOT=false

--- a/back-end/src/app.service.spec.ts
+++ b/back-end/src/app.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { AppService } from './app.service';
+import { SeedService } from './seed/seed.service';
+
+describe('AppService', () => {
+  const buildModule = async (seedFlag: string | undefined) => {
+    const seedExecute = jest.fn();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppService,
+        { provide: SeedService, useValue: { execute: seedExecute } },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) =>
+              key === 'SEED_ON_BOOT' ? seedFlag : undefined,
+          },
+        },
+      ],
+    }).compile();
+
+    return { service: module.get(AppService), seedExecute };
+  };
+
+  it('does not seed when SEED_ON_BOOT is unset', async () => {
+    const { service, seedExecute } = await buildModule(undefined);
+    await service.onApplicationBootstrap();
+    expect(seedExecute).not.toHaveBeenCalled();
+  });
+
+  it('does not seed when SEED_ON_BOOT is "false"', async () => {
+    const { service, seedExecute } = await buildModule('false');
+    await service.onApplicationBootstrap();
+    expect(seedExecute).not.toHaveBeenCalled();
+  });
+
+  it('seeds when SEED_ON_BOOT is "true"', async () => {
+    const { service, seedExecute } = await buildModule('true');
+    await service.onApplicationBootstrap();
+    expect(seedExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/back-end/src/app.service.ts
+++ b/back-end/src/app.service.ts
@@ -1,11 +1,19 @@
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SeedService } from './seed/seed.service';
 
 @Injectable()
 export class AppService implements OnApplicationBootstrap {
-  constructor(private seedService: SeedService) {}
+  constructor(
+    private seedService: SeedService,
+    private configService: ConfigService,
+  ) {}
 
   async onApplicationBootstrap(): Promise<void> {
+    if (this.configService.get<string>('SEED_ON_BOOT') !== 'true') {
+      return;
+    }
+    Logger.log('SEED_ON_BOOT=true — running seed', 'AppService');
     await this.seedService.execute();
   }
 }

--- a/back-end/src/env.validation.ts
+++ b/back-end/src/env.validation.ts
@@ -44,6 +44,10 @@ const envSchema = z.object({
     },
   ),
   PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+  SEED_ON_BOOT: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
 });
 
 export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
## Summary
- Seeding no longer runs on every backend bootstrap. `AppService.onApplicationBootstrap` checks `SEED_ON_BOOT` (via `ConfigService`) and only calls `SeedService.execute()` when it equals `"true"`.
- New env var validated by the existing Zod schema as `z.enum(['true', 'false'])` with default `'false'`; invalid values fail `parseEnv()` and the backend exits with a clear error.
- `.env.dist` and `AGENTS.md` updated.

Closes #33.

## Test plan
- [x] `npm run check`
- [x] `npm run lint`
- [x] `npm test` (31/31 — adds 3 cases in new `app.service.spec.ts` covering unset / `"false"` / `"true"`)
- [x] `npm run build`
- [ ] Manual: `npm run start:dev` with no flag → no seed log; `SEED_ON_BOOT=true npm run start:dev` → seed runs; `SEED_ON_BOOT=banana` → parseEnv exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made database seeding optional via the `SEED_ON_BOOT` environment variable (defaults to disabled).

* **Documentation**
  * Updated environment configuration documentation to reflect conditional seeding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->