### PR TITLE
feat(frontend): error boundary + safe getServerSideProps (#34)

### DIFF
--- a/front-end/src/components/ErrorBoundary.test.tsx
+++ b/front-end/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import { vi, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const Boom = ({ explode }: { explode: boolean }) => {
+  if (explode) throw new Error('boom');
+  return <span>safe</span>;
+};
+
+const renderWithMantine = (ui: React.ReactElement) =>
+  render(<MantineProvider>{ui}</MantineProvider>);
+
+describe('ErrorBoundary', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('renders children when no error is thrown', () => {
+    renderWithMantine(
+      <ErrorBoundary>
+        <Boom explode={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('safe')).toBeInTheDocument();
+  });
+
+  it('renders the default fallback when a child throws', () => {
+    renderWithMantine(
+      <ErrorBoundary>
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText(/Une erreur est survenue/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Réessayer/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a custom fallback when provided', () => {
+    renderWithMantine(
+      <ErrorBoundary fallback={<span>custom-fallback</span>}>
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('custom-fallback')).toBeInTheDocument();
+  });
+
+  it('recovers when the user clicks Réessayer and the child no longer throws', async () => {
+    const Wrapper = () => {
+      const [explode, setExplode] = useState(true);
+      return (
+        <>
+          <button onClick={() => setExplode(false)}>fix</button>
+          <ErrorBoundary>
+            <Boom explode={explode} />
+          </ErrorBoundary>
+        </>
+      );
+    };
+
+    renderWithMantine(<Wrapper />);
+
+    expect(screen.getByText(/Une erreur est survenue/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /fix/i }));
+    await userEvent.click(screen.getByRole('button', { name: /Réessayer/i }));
+
+    expect(screen.getByText('safe')).toBeInTheDocument();
+  });
+});

--- a/front-end/src/components/ErrorBoundary.test.tsx
+++ b/front-end/src/components/ErrorBoundary.test.tsx
@@ -57,6 +57,37 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('custom-fallback')).toBeInTheDocument();
   });
 
+  it('passes the reset handler to a render-prop fallback', async () => {
+    const Wrapper = () => {
+      const [explode, setExplode] = useState(true);
+      return (
+        <>
+          <button onClick={() => setExplode(false)}>fix</button>
+          <ErrorBoundary
+            fallback={(reset) => (
+              <button onClick={reset}>custom-retry</button>
+            )}
+          >
+            <Boom explode={explode} />
+          </ErrorBoundary>
+        </>
+      );
+    };
+
+    renderWithMantine(<Wrapper />);
+
+    expect(
+      screen.getByRole('button', { name: /custom-retry/i }),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /fix/i }));
+    await userEvent.click(
+      screen.getByRole('button', { name: /custom-retry/i }),
+    );
+
+    expect(screen.getByText('safe')).toBeInTheDocument();
+  });
+
   it('recovers when the user clicks Réessayer and the child no longer throws', async () => {
     const Wrapper = () => {
       const [explode, setExplode] = useState(true);

--- a/front-end/src/components/ErrorBoundary.tsx
+++ b/front-end/src/components/ErrorBoundary.tsx
@@ -1,9 +1,11 @@
 import { Button, Container, Stack, Text, Title } from '@mantine/core';
 import { Component, ErrorInfo, ReactNode } from 'react';
 
+type ErrorBoundaryFallback = ReactNode | ((reset: () => void) => ReactNode);
+
 interface ErrorBoundaryProps {
   children: ReactNode;
-  fallback?: ReactNode;
+  fallback?: ErrorBoundaryFallback;
 }
 
 interface ErrorBoundaryState {
@@ -34,8 +36,10 @@ export class ErrorBoundary extends Component<
       return this.props.children;
     }
 
-    if (this.props.fallback) {
-      return this.props.fallback;
+    if (this.props.fallback !== undefined) {
+      return typeof this.props.fallback === 'function'
+        ? this.props.fallback(this.handleReset)
+        : this.props.fallback;
     }
 
     return (

--- a/front-end/src/components/ErrorBoundary.tsx
+++ b/front-end/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Button, Container, Stack, Text, Title } from '@mantine/core';
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error:', error, info.componentStack);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback;
+    }
+
+    return (
+      <Container py="xl">
+        <Stack align="center" spacing="md">
+          <Title order={2}>Une erreur est survenue</Title>
+          <Text c="dimmed" ta="center">
+            Quelque chose s&apos;est mal passé. Vous pouvez réessayer ou
+            recharger la page.
+          </Text>
+          <Button onClick={this.handleReset}>Réessayer</Button>
+        </Stack>
+      </Container>
+    );
+  }
+}

--- a/front-end/src/components/index.ts
+++ b/front-end/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './BookmarksList';
 export * from './City';
 export * from './DebugModeToggle';
 export * from './EmptyData';
+export * from './ErrorBoundary';
 export * from './Filters';
 export * from './Form';
 export * from './PageTitle';

--- a/front-end/src/pages/_app.tsx
+++ b/front-end/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { Topbar } from '@/components';
+import { ErrorBoundary, Topbar } from '@/components';
 import { AuthProvider, SnackbarProvider } from '@/contexts';
 import { routes } from '@/routes';
 import { graphqlClient } from '@/graphql/apollo';
@@ -15,7 +15,9 @@ export default function App({ Component, pageProps }: AppProps) {
           <AuthProvider>
             <Topbar routes={routes} />
             <Container>
-              <Component {...pageProps} />
+              <ErrorBoundary>
+                <Component {...pageProps} />
+              </ErrorBoundary>
             </Container>
           </AuthProvider>
         </ApolloProvider>

--- a/front-end/src/pages/_app.tsx
+++ b/front-end/src/pages/_app.tsx
@@ -13,12 +13,12 @@ export default function App({ Component, pageProps }: AppProps) {
       <SnackbarProvider>
         <ApolloProvider client={graphqlClient}>
           <AuthProvider>
-            <Topbar routes={routes} />
-            <Container>
-              <ErrorBoundary>
+            <ErrorBoundary>
+              <Topbar routes={routes} />
+              <Container>
                 <Component {...pageProps} />
-              </ErrorBoundary>
-            </Container>
+              </Container>
+            </ErrorBoundary>
           </AuthProvider>
         </ApolloProvider>
       </SnackbarProvider>

--- a/front-end/src/pages/activities/[id].tsx
+++ b/front-end/src/pages/activities/[id].tsx
@@ -6,6 +6,7 @@ import {
   GetActivityQueryVariables,
 } from '@/graphql/generated/types';
 import GetActivity from '@/graphql/queries/activity/getActivity';
+import { safeSSR } from '@/utils';
 import { Badge, Flex, Grid, Group, Image, Text } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -15,20 +16,19 @@ interface ActivityDetailsProps {
   activity: GetActivityQuery['getActivity'];
 }
 
-export const getServerSideProps: GetServerSideProps<
-  ActivityDetailsProps
-> = async ({ params, req }) => {
-  if (!params?.id || Array.isArray(params.id)) return { notFound: true };
-  const response = await graphqlClient.query<
-    GetActivityQuery,
-    GetActivityQueryVariables
-  >({
-    query: GetActivity,
-    variables: { id: params.id },
-    context: { headers: { Cookie: req.headers.cookie } },
+export const getServerSideProps: GetServerSideProps<ActivityDetailsProps> =
+  safeSSR<ActivityDetailsProps>(async ({ params, req }) => {
+    if (!params?.id || Array.isArray(params.id)) return { notFound: true };
+    const response = await graphqlClient.query<
+      GetActivityQuery,
+      GetActivityQueryVariables
+    >({
+      query: GetActivity,
+      variables: { id: params.id },
+      context: { headers: { Cookie: req.headers.cookie } },
+    });
+    return { props: { activity: response.data.getActivity } };
   });
-  return { props: { activity: response.data.getActivity } };
-};
 
 export default function ActivityDetails({ activity }: ActivityDetailsProps) {
   const router = useRouter();

--- a/front-end/src/pages/discover.tsx
+++ b/front-end/src/pages/discover.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/graphql/generated/types';
 import GetActivities from '@/graphql/queries/activity/getActivities';
 import { useAuth } from '@/hooks';
+import { safeSSR } from '@/utils';
 import { Button, Grid, Group } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -15,17 +16,17 @@ interface DiscoverProps {
   activities: GetActivitiesQuery['getActivities'];
 }
 
-export const getServerSideProps: GetServerSideProps<
-  DiscoverProps
-> = async () => {
-  const response = await graphqlClient.query<
-    GetActivitiesQuery,
-    GetActivitiesQueryVariables
-  >({
-    query: GetActivities,
-  });
-  return { props: { activities: response.data.getActivities } };
-};
+export const getServerSideProps: GetServerSideProps<DiscoverProps> = safeSSR(
+  async () => {
+    const response = await graphqlClient.query<
+      GetActivitiesQuery,
+      GetActivitiesQueryVariables
+    >({
+      query: GetActivities,
+    });
+    return { props: { activities: response.data.getActivities } };
+  },
+);
 
 export default function Discover({ activities }: DiscoverProps) {
   const { user } = useAuth();

--- a/front-end/src/pages/explorer/[city].tsx
+++ b/front-end/src/pages/explorer/[city].tsx
@@ -6,6 +6,7 @@ import {
 } from '@/graphql/generated/types';
 import GetActivitiesByCity from '@/graphql/queries/activity/getActivitiesByCity';
 import { useDebounced } from '@/hooks';
+import { safeSSR } from '@/utils';
 import { Divider, Flex, Grid } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -18,33 +19,34 @@ interface CityDetailsProps {
   city: string;
 }
 
-export const getServerSideProps: GetServerSideProps<CityDetailsProps> = async ({
-  params,
-  query,
-}) => {
-  if (!params?.city || Array.isArray(params.city)) return { notFound: true };
+export const getServerSideProps: GetServerSideProps<CityDetailsProps> =
+  safeSSR<CityDetailsProps>(async ({ params, query }) => {
+    if (!params?.city || Array.isArray(params.city)) return { notFound: true };
 
-  if (
-    (query.activity && Array.isArray(query.activity)) ||
-    (query.price && Array.isArray(query.price))
-  )
-    return { notFound: true };
+    if (
+      (query.activity && Array.isArray(query.activity)) ||
+      (query.price && Array.isArray(query.price))
+    )
+      return { notFound: true };
 
-  const response = await graphqlClient.query<
-    GetActivitiesByCityQuery,
-    GetActivitiesByCityQueryVariables
-  >({
-    query: GetActivitiesByCity,
-    variables: {
-      city: params.city,
-      activity: query.activity || null,
-      price: query.price ? Number(query.price) : null,
-    },
+    const response = await graphqlClient.query<
+      GetActivitiesByCityQuery,
+      GetActivitiesByCityQueryVariables
+    >({
+      query: GetActivitiesByCity,
+      variables: {
+        city: params.city,
+        activity: query.activity || null,
+        price: query.price ? Number(query.price) : null,
+      },
+    });
+    return {
+      props: {
+        activities: response.data.getActivitiesByCity,
+        city: params.city,
+      },
+    };
   });
-  return {
-    props: { activities: response.data.getActivitiesByCity, city: params.city },
-  };
-};
 
 export default function ActivityDetails({
   activities,

--- a/front-end/src/pages/explorer/[city].tsx
+++ b/front-end/src/pages/explorer/[city].tsx
@@ -29,6 +29,10 @@ export const getServerSideProps: GetServerSideProps<CityDetailsProps> =
     )
       return { notFound: true };
 
+    const parsedPrice = query.price ? parseFloat(query.price as string) : null;
+    const price =
+      parsedPrice !== null && Number.isFinite(parsedPrice) ? parsedPrice : null;
+
     const response = await graphqlClient.query<
       GetActivitiesByCityQuery,
       GetActivitiesByCityQueryVariables
@@ -37,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<CityDetailsProps> =
       variables: {
         city: params.city,
         activity: query.activity || null,
-        price: query.price ? Number(query.price) : null,
+        price,
       },
     });
     return {

--- a/front-end/src/pages/explorer/index.tsx
+++ b/front-end/src/pages/explorer/index.tsx
@@ -5,6 +5,7 @@ import {
   GetCitiesQueryVariables,
 } from '@/graphql/generated/types';
 import GetCities from '@/graphql/queries/city/getCities';
+import { safeSSR } from '@/utils';
 import { Flex } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -13,17 +14,17 @@ interface ExplorerProps {
   cities: GetCitiesQuery['getCities'];
 }
 
-export const getServerSideProps: GetServerSideProps<
-  ExplorerProps
-> = async () => {
-  const response = await graphqlClient.query<
-    GetCitiesQuery,
-    GetCitiesQueryVariables
-  >({
-    query: GetCities,
-  });
-  return { props: { cities: response.data.getCities } };
-};
+export const getServerSideProps: GetServerSideProps<ExplorerProps> = safeSSR(
+  async () => {
+    const response = await graphqlClient.query<
+      GetCitiesQuery,
+      GetCitiesQueryVariables
+    >({
+      query: GetCities,
+    });
+    return { props: { cities: response.data.getCities } };
+  },
+);
 
 export default function Explorer({ cities }: ExplorerProps) {
   return (

--- a/front-end/src/pages/index.tsx
+++ b/front-end/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Activity, PageTitle } from '@/components';
 import { graphqlClient } from '@/graphql/apollo';
-import { useGlobalStyles } from '@/utils';
+import { safeSSR, useGlobalStyles } from '@/utils';
 import { Button, Flex, Grid, Text } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -15,16 +15,18 @@ interface HomeProps {
   activities: GetLatestActivitiesQuery['getLatestActivities'];
 }
 
-export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
-  const response = await graphqlClient.query<
-    GetLatestActivitiesQuery,
-    GetLatestActivitiesQueryVariables
-  >({
-    query: GetLatestActivities,
-  });
+export const getServerSideProps: GetServerSideProps<HomeProps> = safeSSR(
+  async () => {
+    const response = await graphqlClient.query<
+      GetLatestActivitiesQuery,
+      GetLatestActivitiesQueryVariables
+    >({
+      query: GetLatestActivities,
+    });
 
-  return { props: { activities: response.data.getLatestActivities } };
-};
+    return { props: { activities: response.data.getLatestActivities } };
+  },
+);
 
 export default function Home({ activities }: HomeProps) {
   const { classes } = useGlobalStyles();

--- a/front-end/src/pages/my-activities.tsx
+++ b/front-end/src/pages/my-activities.tsx
@@ -7,6 +7,7 @@ import {
 import GetUserActivities from '@/graphql/queries/activity/getUserActivities';
 import { withAuth } from '@/hocs';
 import { useAuth } from '@/hooks';
+import { safeSSR } from '@/utils';
 import { Button, Grid, Group } from '@mantine/core';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -16,18 +17,17 @@ interface MyActivitiesProps {
   activities: GetUserActivitiesQuery['getActivitiesByUser'];
 }
 
-export const getServerSideProps: GetServerSideProps<
-  MyActivitiesProps
-> = async ({ req }) => {
-  const response = await graphqlClient.query<
-    GetUserActivitiesQuery,
-    GetUserActivitiesQueryVariables
-  >({
-    query: GetUserActivities,
-    context: { headers: { Cookie: req.headers.cookie } },
+export const getServerSideProps: GetServerSideProps<MyActivitiesProps> =
+  safeSSR(async ({ req }) => {
+    const response = await graphqlClient.query<
+      GetUserActivitiesQuery,
+      GetUserActivitiesQueryVariables
+    >({
+      query: GetUserActivities,
+      context: { headers: { Cookie: req.headers.cookie } },
+    });
+    return { props: { activities: response.data.getActivitiesByUser } };
   });
-  return { props: { activities: response.data.getActivitiesByUser } };
-};
 
 const MyActivities = ({ activities }: MyActivitiesProps) => {
   const { user } = useAuth();

--- a/front-end/src/utils/index.ts
+++ b/front-end/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './global.styles';
 export * from './mantine.theme';
+export * from './safeSSR';
 
 export interface City {
   nom: string;

--- a/front-end/src/utils/safeSSR.test.ts
+++ b/front-end/src/utils/safeSSR.test.ts
@@ -29,17 +29,28 @@ describe('safeSSR', () => {
     expect(result).toEqual({ props: { value: 42 } });
   });
 
-  it('returns notFound and logs when the handler throws', async () => {
+  it('returns notFound and logs structured context when the handler throws', async () => {
+    const error = new Error('backend down');
     const handler = safeSSR(async () => {
-      throw new Error('backend down');
+      throw error;
     });
 
-    const result = await handler(ctx({ resolvedUrl: '/my-activities' }));
+    const result = await handler(
+      ctx({
+        resolvedUrl: '/explorer/Paris?activity=hike',
+        params: { city: 'Paris' },
+        query: { activity: 'hike' },
+      }),
+    );
 
     expect(result).toEqual({ notFound: true });
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/my-activities'),
-      expect.any(Error),
+      expect.stringContaining('/explorer/Paris'),
+      {
+        params: { city: 'Paris' },
+        query: { activity: 'hike' },
+        error,
+      },
     );
   });
 

--- a/front-end/src/utils/safeSSR.test.ts
+++ b/front-end/src/utils/safeSSR.test.ts
@@ -1,0 +1,53 @@
+import { GetServerSidePropsContext } from 'next';
+import { vi, beforeEach, afterEach } from 'vitest';
+import { safeSSR } from './safeSSR';
+
+const ctx = (overrides: Partial<GetServerSidePropsContext> = {}) =>
+  ({
+    resolvedUrl: '/test',
+    ...overrides,
+  } as GetServerSidePropsContext);
+
+describe('safeSSR', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('passes through the handler result on success', async () => {
+    const handler = safeSSR<{ value: number }>(async () => ({
+      props: { value: 42 },
+    }));
+
+    const result = await handler(ctx());
+
+    expect(result).toEqual({ props: { value: 42 } });
+  });
+
+  it('returns notFound and logs when the handler throws', async () => {
+    const handler = safeSSR(async () => {
+      throw new Error('backend down');
+    });
+
+    const result = await handler(ctx({ resolvedUrl: '/my-activities' }));
+
+    expect(result).toEqual({ notFound: true });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/my-activities'),
+      expect.any(Error),
+    );
+  });
+
+  it('passes through redirects and notFound results from the handler', async () => {
+    const handler = safeSSR(async () => ({ notFound: true }));
+
+    const result = await handler(ctx());
+
+    expect(result).toEqual({ notFound: true });
+  });
+});

--- a/front-end/src/utils/safeSSR.ts
+++ b/front-end/src/utils/safeSSR.ts
@@ -1,0 +1,15 @@
+import { GetServerSideProps } from 'next';
+
+export function safeSSR<P extends { [key: string]: any }>(
+  handler: GetServerSideProps<P>,
+): GetServerSideProps<P> {
+  return async (context) => {
+    try {
+      return await handler(context);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`[SSR] ${context.resolvedUrl} failed:`, error);
+      return { notFound: true };
+    }
+  };
+}

--- a/front-end/src/utils/safeSSR.ts
+++ b/front-end/src/utils/safeSSR.ts
@@ -8,7 +8,11 @@ export function safeSSR<P extends { [key: string]: any }>(
       return await handler(context);
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error(`[SSR] ${context.resolvedUrl} failed:`, error);
+      console.error(`[SSR] ${context.resolvedUrl} failed`, {
+        params: context.params,
+        query: context.query,
+        error,
+      });
       return { notFound: true };
     }
   };


### PR DESCRIPTION
## Summary
- New `ErrorBoundary` (class component) mounted around the page outlet in `_app.tsx`. Catches render errors and shows a friendly Mantine fallback with a **Réessayer** reset button.
- New `safeSSR` helper wrapping every `getServerSideProps` body in try/catch — on error, logs with `resolvedUrl` and returns `notFound: true`, so a transient backend hiccup yields a 404 instead of a raw 500.
- Applied to all 6 SSR pages (`index`, `discover`, `explorer/index`, `explorer/[city]`, `my-activities`, `activities/[id]`). Internal `notFound` returns from each handler still pass through unchanged.

Closes #34.

## Test plan
- [x] `npm run check`
- [x] `npm run lint` (no new warnings)
- [x] `npm test` — 24/24 (4 new `ErrorBoundary` cases inc. retry recovery, 3 new `safeSSR` cases)
- [x] `npm run build`
- [ ] Manual: stop backend, hit `/`, `/discover`, `/my-activities`, `/activities/[id]` → 404 instead of 500
- [ ] Manual: throw inside a page render → friendly fallback instead of white screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a global error boundary with a French default message and a retry option to recover from rendering errors.
  - Introduced a server-side safety wrapper that converts unexpected handler failures into graceful 404 responses.

* **Tests**
  - Added test suites verifying error-boundary behavior (fallbacks, reset/retry) and the server-side safety wrapper's error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->